### PR TITLE
Add `finish_u128` to `hasher.rs`

### DIFF
--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -35,6 +35,18 @@ impl GxHasher {
         // Use gxhash64 to generate an initial state from a seed
         GxHasher(unsafe { gxhash(&[], create_seed(seed)) })
     }
+
+    /// Finish this hasher and return the hashed value as a 128 bit
+    /// unsigned integer.
+    #[inline]
+    fn finish_u128(&self) -> u128 {
+        debug_assert!(std::mem::size_of::<State>() >= std::mem::size_of::<u128>());
+
+        unsafe {
+            let p = &self.0 as *const State as *const u128;
+            *p
+        }
+    }
 }
 
 impl Hasher for GxHasher {


### PR DESCRIPTION
This adds an additional method on `Hasher` allow the user to get a 128-bit key as an output. This is useful for applications that rely on a large key (and hopefully low collisions) for distinguishing between object. In my case, I need this feature to experiment about the possibility of using GxHash to replace SipHasher in another project I am a contributor of.