### PR TITLE
improve target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Check out the [paper](https://github.com/ogxd/gxhash-rust/blob/main/article/arti
 
 ### Architecture Compatibility
 GxHash is compatible with:
-- X86 processors with `AES-NI` intrinsics
-- ARM processors with `NEON` intrinsics
+- X86 processors with `AES-NI` & `SSE2` intrinsics
+- ARM processors with `AES` & `NEON` intrinsics
 > **Warning**
-> Other platforms are currently not supported (there is no fallback). The behavior on these platforms is undefined.
+> Other platforms are currently not supported (there is no fallback). GxHash will not build on these platforms.
 
 ### Hashes Stability
 All generated hashes for a given version of GxHash are stable, meaning that for a given input the output hash will be the same across all supported platforms.

--- a/src/gxhash/platform/arm.rs
+++ b/src/gxhash/platform/arm.rs
@@ -1,3 +1,6 @@
+#[cfg(target_arch = "arm")]
+use core::arch::arm::*;
+#[cfg(target_arch = "aarch64")]
 use core::arch::aarch64::*;
 
 use super::*;
@@ -21,6 +24,7 @@ pub unsafe fn load_unaligned(p: *const State) -> State {
 
 #[inline(always)]
 pub unsafe fn get_partial(p: *const State, len: usize) -> State {
+    // Safety check
     if check_same_page(p) {
         get_partial_unsafe(p, len)
     } else {
@@ -48,11 +52,6 @@ pub unsafe fn get_partial_unsafe(data: *const State, len: usize) -> State {
 }
 
 #[inline(always)]
-pub unsafe fn ld(array: *const u32) -> State {
-    vreinterpretq_s8_u32(vld1q_u32(array))
-}
-
-#[inline(always)]
 // See https://blog.michaelbrase.com/2018/05/08/emulating-x86-aes-intrinsics-on-armv8-a
 pub unsafe fn aes_encrypt(data: State, keys: State) -> State {
     // Encrypt
@@ -70,6 +69,11 @@ pub unsafe fn aes_encrypt_last(data: State, keys: State) -> State {
     let encrypted = vaeseq_u8(vreinterpretq_u8_s8(data), vdupq_n_u8(0));
     // Xor keys
     vreinterpretq_s8_u8(veorq_u8(encrypted, vreinterpretq_u8_s8(keys)))
+}
+
+#[inline(always)]
+pub unsafe fn ld(array: *const u32) -> State {
+    vreinterpretq_s8_u32(vld1q_u32(array))
 }
 
 #[inline(always)]

--- a/src/gxhash/platform/mod.rs
+++ b/src/gxhash/platform/mod.rs
@@ -1,9 +1,9 @@
-#[cfg(target_arch = "aarch64")]
-#[path = "aarch64.rs"]
+#[cfg(all(any(target_arch = "arm", target_arch = "aarch64"), target_feature = "aes", target_feature = "neon"))]
+#[path = "arm.rs"]
 mod platform;
 
-#[cfg(target_arch = "x86_64")]
-#[path = "x86_64.rs"]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "aes", target_feature = "sse2"))]
+#[path = "x86.rs"]
 mod platform;
 
 pub use platform::*;

--- a/src/gxhash/platform/x86.rs
+++ b/src/gxhash/platform/x86.rs
@@ -1,3 +1,6 @@
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
 use super::*;


### PR DESCRIPTION
- Allow 32-bit targets
- Only build on targets w/ the required intrinsics
- Format ARM code like X86 code