### PR TITLE
Add GxBuildHasher::with_seed

### DIFF
--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -137,6 +137,19 @@ use std::collections::hash_map::RandomState;
 #[rustversion::since(1.76)]
 use std::hash::RandomState;
 
+impl GxBuildHasher {
+    /// Creates a new builder using the provided seed.
+    ///
+    /// # Warning ⚠️
+    /// Hardcoding a seed may make your [`Hasher`] vulnerable to DOS attacks.
+    /// It is recommended to use [`GxBuildHasher::default()`] for improved DOS resistance.
+    #[inline]
+    pub fn with_seed(seed: i64) -> GxBuildHasher {
+        // Use gxhash64 to generate an initial state from a seed
+        GxBuildHasher(unsafe { create_seed(seed) })
+    }
+}
+
 impl Default for GxBuildHasher {
     #[inline]
     fn default() -> GxBuildHasher {


### PR DESCRIPTION
This PR adds a new method to build a GxBuildHasher with a given seed.
See https://github.com/ogxd/gxhash/issues/79 for the corresponding issue.