### PR TITLE
Changing `target_feature` check so `cargo doc` runs for dependent crates

### DIFF
--- a/src/gxhash/platform/x86.rs
+++ b/src/gxhash/platform/x86.rs
@@ -1,4 +1,4 @@
-#[cfg(not(any(all(target_feature = "aes", target_feature = "sse2"), docsrs)))] // docs.rs bypasses the target_feature check
+#[cfg(not(any(all(target_feature = "aes", target_feature = "sse2"), docsrs, doc)))] // docs.rs bypasses the target_feature check
 compile_error!{"Gxhash requires aes and sse2 intrinsics. Make sure the processor supports it and build with RUSTFLAGS=\"-C target-cpu=native\" or RUSTFLAGS=\"-C target-feature=+aes,+sse2\"."}
 
 #[cfg(all(feature = "hybrid", not(all(target_feature = "aes", target_feature = "avx2"))))]


### PR DESCRIPTION
`cargo doc` filters out build flags, so the `target_feature` check can interfere with documentation builds on downstream crates.

This tiny change fixes that.