### PR TITLE
Added the "deterministic" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ bench-csv = []
 bench-md = []
 bench-plot = []
 hybrid = []
+deterministic = []
 
 [dependencies]
 rustversion = "1.0" # Compile-time cfg based on rustc version for compatibility

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ In order to achieve this magnitude of performance, this crate contains unsafe co
 ### Security
 GxHash is seeded (with seed randomization) to improve DOS resistance and uses a wide (128-bit) internal state to improve multicollision resistance. Yet, such resistances are just basic safeguards and do not make GxHash secure against all attacks.
 
+For use cases that require deterministic repeatability, you can disable random seeding with the feature 
+"deterministic," but this of course disables DOS mitigation. 
+
 Also, it is important to note that GxHash is not a cryptographic hash function and should not be used for cryptographic purposes.
 
 ## Usage


### PR DESCRIPTION
I added the feature "deterministic", which effectively disables random seeding. The implementation is the most minimally invasive: When the feature is enabled the random seed is set to a constant. Two tests were modified to check that random seeding is or is not occurring according to whether the feature is enabled. I added a mention of the feature in a couple of places that seemed reasonable to me.

Deterministic reproducibility is required in some scientific applications.